### PR TITLE
Fix einsum index order and block-by-block O†O for SlicedJacobian

### DIFF
--- a/.claude/skills/check-efficiency/SKILL.md
+++ b/.claude/skills/check-efficiency/SKILL.md
@@ -49,6 +49,14 @@ These checks require understanding the PEPS VMC algorithm and cannot be automate
 - **Rebuilding what's already cached.** Are row MPOs, right environments, or boundary states recomputed when they could be carried from a previous step?
 - **Unnecessary recomputation across MC sweeps.** Does the sampler recompute quantities that are unchanged between sweeps (e.g., static operator structure, bucketed terms)?
 
+### Sparsity in linear algebra
+
+Matrices arising from the physics often have known sparsity or block structure (e.g., slicing by physical index, gauge sectors, blockade constraints). For every `@` (matmul), solve, or decomposition on such matrices, check whether the code exploits the structure or falls back to dense operations.
+
+- **Unnecessary densification.** Does a compact/sparse representation get expanded to dense form before a matmul or solve? The operation can often be done directly on the compact form (block-by-block accumulation, masked operations, etc.).
+- **Ignored block structure.** When the physics guarantees that certain blocks are zero (e.g., cross-slice blocks within a site), check that these zero blocks are never computed.
+- **Consistency across code paths.** If multiple dispatch paths exist for the same operation (e.g., different space types, different Jacobian types), check that ALL paths exploit structure — not just some.
+
 ### Memory and data flow
 
 - **Large intermediate tensors.** Flag any contraction that produces intermediates much larger than the inputs (e.g., O(Dc^3) when O(Dc^2) is achievable).

--- a/src/vmc/peps/common/energy.py
+++ b/src/vmc/peps/common/energy.py
@@ -298,7 +298,7 @@ def _compute_single_gradient(
     Returns gradient tensor with shape (up, down, mL, mR).
     """
     return jnp.einsum(
-        "ace,aub,evf,bdf->ucvd", left_env, top_tensor, bot_tensor, right_env,
+        "ace,aub,evf,bdf->uvcd", left_env, top_tensor, bot_tensor, right_env,
         optimize=[(0, 1), (0, 1), (0, 1)],
     )
 

--- a/src/vmc/qgt/qgt.py
+++ b/src/vmc/qgt/qgt.py
@@ -196,9 +196,24 @@ def _to_dense(jac: Jacobian, space: SampleSpace):
 
 @dispatch
 def _to_dense(jac: SlicedJacobian, space: ParameterSpace):
-    O = _sliced_dense_blocks(jac)
-    scale = 1.0 / jac.o.shape[0]
-    S = (O.conj().T @ O) * scale
+    o, p = jac.o, jac.p
+    scale = 1.0 / o.shape[0]
+    blocks = list(_iter_sliced_blocks(o, p, jac.sliced_dims, jac.ordering))
+    n = len(blocks)
+    # O†O is Hermitian — compute only upper-triangle blocks o_i† @ o_j (j >= i)
+    ut = [[None] * n for _ in range(n)]
+    for i in range(n):
+        oi = blocks[i][0]
+        for j in range(i, n):
+            ut[i][j] = oi.conj().T @ blocks[j][0]
+    # Assemble full Hermitian matrix (fill lower from upper)
+    rows = []
+    for i in range(n):
+        rows.append(jnp.concatenate(
+            [ut[i][j] if j >= i else ut[j][i].conj().T for j in range(n)],
+            axis=1,
+        ))
+    S = jnp.concatenate(rows, axis=0) * scale
     mean = jacobian_mean(jac)
     S = S - mean.conj()[:, None] * mean[None, :]
     return S


### PR DESCRIPTION
## Summary
- Fix `_compute_single_gradient` einsum output index order: `->ucvd` → `->uvcd` to match `(up, down, left, right)` tensor convention (broken by transpose folding in #84)
- Replace dense O expansion in `_to_dense(SlicedJacobian, ParameterSpace)` with block-by-block Hermitian construction using K(K+1)/2 upper-triangle matmuls, avoiding materialization of the full (half-zero) O matrix
- Add sparsity-in-linear-algebra checks to `check-efficiency` skill

## Test plan
- [x] `tests/test_qgt.py` — all 4 tests pass (reorder + solve for both PEPS and GIPEPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)